### PR TITLE
HTMLのみを返すようにapplication.rbでrails g コマンドを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,4 +32,12 @@ module WonderfulPostApp
     # Don't generate system test files.
     config.generators.system_tests = nil
   end
+
+  config.generators do |g|
+    g.jbuilder false
+    g.javascripts false
+    g.stylesheets false
+    g.helper false
+    g.test_framework false
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,13 +31,13 @@ module WonderfulPostApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-  end
 
-  config.generators do |g|
-    g.jbuilder false
-    g.javascripts false
-    g.stylesheets false
-    g.helper false
-    g.test_framework false
+    config.generators do |g|
+      g.jbuilder false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
## 概要
- rails g コマンドで余計なファイルができないようにした