### PR TITLE
 articleのルーティングの実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :sample_articles
+  resources :articles
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 概要
- routes.rbにresources :articlesを追記