### PR TITLE
rails-i18nを導入して日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+#日本語化
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.4)
       actionpack (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -199,6 +202,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
+  rails-i18n
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -25,7 +25,7 @@ class ArticlesController < ApplicationController
 
     respond_to do |format|
       if @article.save
-        format.html { redirect_to article_url(@article), notice: " article was successfully created." }
+        format.html { redirect_to article_url(@article), notice: t(".notice") }
         format.json { render :show, status: :created, location: @article }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -38,7 +38,7 @@ class ArticlesController < ApplicationController
   def update
     respond_to do |format|
       if @article.update(article_params)
-        format.html { redirect_to article_url(@article), notice: " article was successfully updated." }
+        format.html { redirect_to article_url(@article), notice: t(".notice") }
         format.json { render :show, status: :ok, location: @article }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -52,7 +52,7 @@ class ArticlesController < ApplicationController
     @article.destroy
 
     respond_to do |format|
-      format.html { redirect_to articles_url, notice: " article was successfully destroyed." }
+      format.html { redirect_to articles_url, notice: t(".notice") }
       format.json { head :no_content }
     end
   end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -11,17 +11,17 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
+  <div class="mb-3">
+    <%= form.label :title, "タイトル", class: "form-label" %>
+    <%= form.text_field :title, class: "form-control" %>
   </div>
 
   <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content %>
+    <%= form.label :content, "内容", class: "form-label" %>
+    <%= form.text_area :content, class: "form-control" %>
   </div>
 
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit '保存', class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: article, local: true) do |form| %>
   <% if article.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(article.errors.count, "error") %> prohibited this article from being saved:</h2>
+      <h2><%= pluralize(article.errors.count, "つのエラー") %> を修正してください</h2>
 
       <ul>
         <% article.errors.full_messages.each do |message| %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Article</h1>
+<h1><%= t ".Editing Article" %></h1>
 
 <%= render 'form', article: @article %>
 

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Show', @article %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to t('link.Show'), @article %> |
+<%= link_to t('link.Back'), articles_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,13 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Articles</h1>
+<h1><%= t ".Articles" %></h1>
 
-<table>
+<%= link_to '記事作成', new_article_path, class: "btn btn-info" %>
+
+<table class="table">
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
-      <th colspan="3"></th>
+      <th scope="col"><%= t ".Title" %></th>
+      <th scope="col"><%= t ".Content" %></th>
     </tr>
   </thead>
 
@@ -27,5 +28,6 @@
 </table>
 
 <br>
+
 
 <%= link_to 'New Article', new_article_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -16,9 +16,11 @@
       <tr>
         <td><%= article.title %></td>
         <td><%= article.content %></td>
-        <td><%= link_to 'Show', article %></td>
-        <td><%= link_to 'Edit', edit_article_path(article) %></td>
-        <td><%= link_to 'Destroy', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td>
+          <%= link_to t('link.Show'), article, class: "btn btn-success" %>
+          <%= link_to t('link.Edit'), edit_article_path(article), class: "btn btn-warning" %>
+          <%= link_to t('link.Destroy'), article, class: "btn btn-danger", method: :delete, data: { confirm: t('confirm.Are you sure?') } %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Back', articles_path %>
+<%= link_to t('link.Back'), articles_path %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Article</h1>
+<h1><%= t(".New Article") %></h1>
 
 <%= render 'form', article: @article %>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -8,7 +8,7 @@
 <p>
   <strong>Content:</strong>
   <%= @article.content %>
-</p>
-
-<%= link_to 'Edit', edit_article_path(@article) %> |
-<%= link_to 'Back', articles_path %>
+  </div>
+</div>
+<%= link_to t('link.Show'), edit_article_path(@article), class: "btn btn-warning" %>
+<%= link_to t('link.Back'), articles_path, class: "btn btn-secondary" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,5 +10,5 @@
   <%= @article.content %>
   </div>
 </div>
-<%= link_to t('link.Show'), edit_article_path(@article), class: "btn btn-warning" %>
+<%= link_to t('link.Edit'), edit_article_path(@article), class: "btn btn-warning" %>
 <%= link_to t('link.Back'), articles_path, class: "btn btn-secondary" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,17 @@ module WonderfulPostApp
       g.helper false
       g.test_framework false
     end
+
+    class Application < Rails::Application
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
+
+    #　以下の記述を追記する(設定必須)
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+    #　以下の記述を追記する(設定必須)
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    end
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,3 +1,4 @@
+ja:
   link:
     Show: '詳細'
     Edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,3 +1,11 @@
+  link:
+    Show: '詳細'
+    Edit: '編集'
+    Destroy: '削除'
+    New Article: '新規作成'
+    Back: '戻る'
+  confirm:
+    Are you sure?: '本当によろしいですか？'
   articles:
     create:
       notice: '記事を作成しました'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,7 @@
+  articles:
+    create:
+      notice: '記事を作成しました'
+    update:
+      notice: '記事を更新しました'
+    destroy:
+      notice: '記事を削除しました'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  articles:
+    index:
+      Articles: '記事一覧'
+      Title: 'タイトル'
+      Content: '内容'
+    new:
+      New Article: '新規作成'
+      title: 'タイトル'
+      content: '内容'
+    edit:
+      Editing Article: '記事編集'
+    show:
+      Title: 'タイトル'
+      Content: '内容'


### PR DESCRIPTION
## 概要
- アプリケーションのlocalを日本語に設定
- デフォルトのタイムゾーンも日本に設定
- articleモデル関連の表示部分やフラッシュメッセージを日本語化
- localsディレクトリにja.ymlファイルを作成
```
config.active_record.default_timezone = :local
config.i18n.default_locale = :ja
config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
```